### PR TITLE
style loader webpack.prod.js

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -14,8 +14,8 @@ app.get('/', function (req, res) {
 })
 
 // designates what port the app will listen to for incoming requests
-app.listen(8082, function () {
-    console.log('Example app listening on port 8082!')
+app.listen(3000, function () {
+    console.log('Example app listening on port 3000!')
 })
 
 app.get('/test', function (req, res) {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -11,6 +11,10 @@ module.exports = {
                 test: '/\.js$/',
                 exclude: /node_modules/,
                 loader: "babel-loader"
+            },
+            {
+                test: /\.scss$/,
+                use: [ 'style-loader', 'css-loader', 'sass-loader' ]
             }
         ]
     },


### PR DESCRIPTION
I forgot to put the rule for the style loaders in webpack.prod.js. Now the styles are being compiled for both.