### PR TITLE
Api sign up / hide key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -3291,6 +3291,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "description": "",
   "dependencies": {
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,3 +1,6 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
 var path = require('path')
 const express = require('express')
 const mockAPIResponse = require('./mockAPI.js')
@@ -9,6 +12,10 @@ app.use(cors())
 app.use(express.static('dist'))
 
 console.log(__dirname)
+
+//retrieve api key from .env file 
+const apiKey = process.env.API_KEY
+// console.log(`Your api key is:  + ${apiKey}`)
 
 app.get('/', function (req, res) {
     // res.sendFile('dist/index.html')
@@ -23,3 +30,4 @@ app.listen(3000, function () {
 app.get('/test', function (req, res) {
     res.send(mockAPIResponse)
 })
+


### PR DESCRIPTION
After signing up for the MeaningCloud api, I installed dotenv via npm and placed the api key in a .env file. I then added the .env to gitignore.